### PR TITLE
Fix fail to add option bug if img tag contain other data attributes

### DIFF
--- a/src/coffee/BttrLazyLoading.coffee
+++ b/src/coffee/BttrLazyLoading.coffee
@@ -55,7 +55,7 @@ class BttrLazyLoading
 			if v
 				# making sure we only use bttrlazyloading data
 				if i.indexOf('bttrlazyloading') isnt 0
-					return false
+					return
 				i = i.replace('bttrlazyloading', '').replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase().split '-'
 				if i.length > 1
 					@options[i[0]][i[1]] = v if typeof @options[i[0]][i[1]] isnt 'undefined'


### PR DESCRIPTION
`return false` will break the `each` loop, which may skip other data attributes, and the option parsing may fail.